### PR TITLE
Feature: Public /worlds Page

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -73,7 +73,6 @@ const authGuard: Handle = async ({ event, resolve }) => {
 		!event.url.pathname.startsWith('/resources') &&
 		!event.url.pathname.startsWith('/worlds')
 	) {
-		console.log('Auth Denied - redirecting')
 		redirect(303, '/');
 	}
 

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -70,8 +70,10 @@ const authGuard: Handle = async ({ event, resolve }) => {
 		!event.locals.session &&
 		event.url.pathname.length > 1 &&
 		!event.url.pathname.startsWith('/auth') &&
-		!event.url.pathname.startsWith('/resources')
+		!event.url.pathname.startsWith('/resources') &&
+		!event.url.pathname.startsWith('/worlds')
 	) {
+		console.log('Auth Denied - redirecting')
 		redirect(303, '/');
 	}
 

--- a/src/routes/worlds/+page.svelte
+++ b/src/routes/worlds/+page.svelte
@@ -1,45 +1,8 @@
 <script lang="ts">
-	import driver from '$lib/db/neo4j';
-	import { Integer, Node } from 'neo4j-driver';
-	import type { PageProps } from './$types';
+	import Dashboard from '$lib/components/Dashboard.svelte';
+	import type { GraphData } from '$lib/types/graph';
 
-	const { data }: PageProps = $props();
-	const { count } = $derived(data);
-
-	const cypher = 'MATCH (p:Project) RETURN p AS Project LIMIT 10';
-
-	interface ProjectProps {
-		title: string;
-	}
-
-	type Project = Node<Integer, ProjectProps>;
-
-	let projects: Project[] = $state([]);
-	let awaiting = $state(false);
-
-	async function send() {
-		const session = driver.session();
-		awaiting = true;
-		try {
-			const res = await session.executeRead((tx) => tx.run(cypher));
-			projects = res.records.map((record) => record.get('Project'));
-		} finally {
-			awaiting = false;
-			await session.close();
-		}
-	}
+	export let data: { graphData: GraphData };
 </script>
 
-<h1>Welcome to Obsidian 2.0.0 😎</h1>
-<p>Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to read the documentation</p>
-<button onclick={send}>Get Projects</button>
-
-{#if awaiting}
-	<p>loading will take {count} seconds</p>
-{:else if projects}
-	<ul>
-		{#each projects as project (project.identity)}
-			<li>{project.properties.title}</li>
-		{/each}
-	</ul>
-{/if}
+<Dashboard graphData={data.graphData}></Dashboard>

--- a/src/routes/worlds/+page.ts
+++ b/src/routes/worlds/+page.ts
@@ -1,0 +1,19 @@
+import type { Load } from '@sveltejs/kit';
+import type { GraphData } from '$lib/types/graph';
+
+export const load: Load = async ({ fetch }) => {
+	const res = await fetch('/worlds');
+	if (!res.ok) throw new Error('Failed to fetch graph data');
+
+	const graphData: GraphData = await res.json();
+
+	graphData.nodes = graphData.nodes.map((node) => ({
+		...node,
+		data: {
+			...node.data,
+			label: node.data.name || node.data.title || 'Untitled'
+		}
+	}));
+
+	return { graphData };
+};

--- a/src/routes/worlds/+server.ts
+++ b/src/routes/worlds/+server.ts
@@ -1,0 +1,38 @@
+import driver from '$lib/db/neo4j';
+import type { RequestHandler } from '@sveltejs/kit';
+import { json } from '@sveltejs/kit';
+import type { GraphData, GraphNode } from '$lib/types/graph';
+
+export const GET: RequestHandler = async () => {
+	const session = driver.session();
+
+	try {
+		const result = await session.run(
+			`
+      MATCH (w:World)
+      RETURN w
+    `
+		);
+
+		const nodes: GraphNode[] = [];
+
+		for (const rec of result.records) {
+			const w = rec.get('w');
+			nodes.push({
+				data: { id: w.identity.toString(), label: w.labels[0], ...w.properties }
+			});
+		}
+
+		const graphData: GraphData = {
+			nodes: nodes,
+			edges: []
+		};
+
+		return json(graphData);
+	} catch (err) {
+		console.error(err);
+		return new Response('Error querying graph', { status: 500 });
+	} finally {
+		await session.close();
+	}
+};

--- a/src/test/e2e/worlds-page.spec.ts
+++ b/src/test/e2e/worlds-page.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test('Worlds page should load and display the dashboard', async ({ page }) => {
+	await page.goto('/worlds');
+	const dashboard = page.getByTestId('dashboard');
+	await expect(dashboard).toBeVisible();
+});


### PR DESCRIPTION
### **User description**
- Closes #62

---

## Summary

This PR makes the `/worlds` page publicly accessible and replaces the existing placeholder with a functioning dashboard view.

- Updated `hooks.server.ts` to unguard the `/worlds` route for unauthenticated users
- Fetched and displayed all **public** worlds from the database
- Reused the existing dashboard component from `/worlds/:id` to render the worlds as a graph
- Current logic is a copy-paste of `/worlds/:id` — future refactor is planned to DRY this up

This lays the groundwork for future features such as search, user role indicators (`OWNER_OF`, `CAN_VIEW`, `CAN_EDIT`), and visual dashboard modifications.

---

## Tests

File: `src/test/e2e/worlds-page.spec.ts`

- Verified that the `/worlds` page renders successfully
- Confirmed that it is publicly accessible without requiring authentication
- No functional interaction tests yet, as this PR focuses on read-only display of public worlds

To run:
```bash
npm run test:e2e
```

*For manual testing. Go to the netlify preview and navigate to /worlds*

---

## Accessibility

- The accessible, non-graph version of the `/worlds` page is out of scope for this PR
- Future iterations will address screen-reader and keyboard navigability needs

---


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Ungate `/worlds` route for public access

- Add GET endpoint returning all worlds graph

- Fetch and render graph in Dashboard component

- Include E2E test for dashboard visibility


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Page Load `/worlds`"] -- "fetch graph data" --> B["GET `/worlds` handler"]
  B -- "run Cypher query" --> C["Neo4j DB"]
  C -- "return nodes" --> B
  B -- "json(GraphData)" --> A
  A -- "render graph" --> D["Dashboard component"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hooks.server.ts</strong><dd><code>Allow public access to `/worlds` route</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hooks.server.ts

- Exempt `/worlds` path from auth guard
- Preserve other route checks


</details>


  </td>
  <td><a href="https://github.com/fac-31/Pro0623-ObsidianTwoPointOPointO/pull/63/files#diff-b5aa13ce0a61c3f166000471d0729aa6a8e57292fdbd8d88452443502e4b9a4a">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>+page.ts</strong><dd><code>Fetch and prepare graph data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/routes/worlds/+page.ts

<li>Implement load function fetching <code>/worlds</code><br> <li> Map node data to include <code>label</code>


</details>


  </td>
  <td><a href="https://github.com/fac-31/Pro0623-ObsidianTwoPointOPointO/pull/63/files#diff-87a1f5e0c2d70a8333e1af41ca20e6063d6761857f0aefed9c3027ffb51533fc">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>+server.ts</strong><dd><code>GET handler for worlds graph data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/routes/worlds/+server.ts

<li>Add GET handler querying all <code>World</code> nodes<br> <li> Build <code>GraphData</code> with nodes and empty edges<br> <li> Handle errors and close session


</details>


  </td>
  <td><a href="https://github.com/fac-31/Pro0623-ObsidianTwoPointOPointO/pull/63/files#diff-caf966023e0aadee7d84bd3cd0eaa93ca66a4a81e1ee9f846903620137492ca4">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>+page.svelte</strong><dd><code>Integrate Dashboard component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/routes/worlds/+page.svelte

<li>Replace placeholder with <code>Dashboard</code> component<br> <li> Accept <code>graphData</code> prop in script<br> <li> Remove legacy project listing code


</details>


  </td>
  <td><a href="https://github.com/fac-31/Pro0623-ObsidianTwoPointOPointO/pull/63/files#diff-cb3dde768180155aa42e6400cb993e7a6a7bab129e10415588a284a4e858b759">+4/-41</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>worlds-page.spec.ts</strong><dd><code>E2E test for worlds dashboard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/e2e/worlds-page.spec.ts

<li>Add E2E test for <code>/worlds</code> page load<br> <li> Verify dashboard visibility by <code>data-testid</code>


</details>


  </td>
  <td><a href="https://github.com/fac-31/Pro0623-ObsidianTwoPointOPointO/pull/63/files#diff-c3b08724880cd6c092add87ad02c92252580969dc35276d215bc01394a4ee194">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>