### PR TITLE
Tabs

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -2,5 +2,5 @@
 @plugin "daisyui" {
 	themes:
 		light --default,
-		black;
+		wireframe;
 }

--- a/src/app.css
+++ b/src/app.css
@@ -2,5 +2,5 @@
 @plugin "daisyui" {
 	themes:
 		light --default,
-		aqua;
+		black;
 }

--- a/src/app.html
+++ b/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-theme="aqua">
+<html lang="en" data-theme="black">
 	<head>
 		<title>Our Worlds</title>
 		<meta charset="utf-8" />

--- a/src/app.html
+++ b/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-theme="black">
+<html lang="en" data-theme="wireframe">
 	<head>
 		<title>Our Worlds</title>
 		<meta charset="utf-8" />

--- a/src/lib/components/FloatingButton.svelte
+++ b/src/lib/components/FloatingButton.svelte
@@ -6,20 +6,19 @@
 </script>
 
 <div class={`dropdown dropdown-top dropdown-center ${position}`}>
-	<div
-		tabindex="0"
-		role="button"
-		class="btn m-1 text-2xl bg-secondary text-primary-content rounded-full shadow-lg hover:bg-primary-focus focus:outline-none focus:ring-4 focus:ring-primary/50"
+	<button
 		aria-label={ariaLabel}
+		class="btn m-1 text-2xl bg-secondary text-primary-content rounded-full shadow-lg hover:bg-primary-focus focus:outline-none focus:ring-4 focus:ring-primary/50"
 	>
 		+
-	</div>
-	<ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-10 w-52 p-2 shadow-sm">
+	</button>
+
+	<ul class="dropdown-content menu bg-base-100 rounded-box z-10 w-52 p-2 shadow-sm">
 		<li>
-			<a href="#" on:click|preventDefault={onDisplayText}>Display Text</a>
+			<button type="button" on:click={onDisplayText}>Display Text</button>
 		</li>
 		<li>
-			<a href="#" on:click|preventDefault={onCreateNew}>Create New</a>
+			<button type="button" on:click={onCreateNew}>Create New</button>
 		</li>
 	</ul>
 </div>

--- a/src/lib/components/GraphView.svelte
+++ b/src/lib/components/GraphView.svelte
@@ -2,7 +2,7 @@
 	import { onMount, onDestroy } from 'svelte';
 	import cytoscape from 'cytoscape';
 	import type { GraphData } from '$lib/types/graph';
-	import { selectedNode } from '$lib/stores/selectedNode';
+	import { selectedNodesStore } from '$lib/stores/selectedNodes';
 
 	export let graphData: GraphData;
 
@@ -68,7 +68,7 @@
 
 			// Tapped on background
 			if (target === cy) {
-				selectedNode.set(null);
+				// Keeping tabs open, but visually deselecting
 				cy.nodes().removeClass('selected');
 				cy.elements().removeClass('faded');
 				return;
@@ -77,7 +77,7 @@
 			// Tapped on a node
 			if (target.isNode && target.isNode()) {
 				console.log('Node data:', target.data());
-				selectedNode.set({ data: target.data() });
+				selectedNodesStore.addNode({ data: target.data() });
 
 				cy.nodes().removeClass('selected');
 				cy.elements().removeClass('faded');

--- a/src/lib/components/GraphView.svelte
+++ b/src/lib/components/GraphView.svelte
@@ -20,7 +20,7 @@
 					selector: 'node',
 					style: {
 						label: 'data(label)',
-						'background-color': '#0074D9',
+						'background-color': '#666666',
 						color: '#fff',
 						'text-valign': 'center',
 						'text-halign': 'center',

--- a/src/lib/components/InfoPanel.svelte
+++ b/src/lib/components/InfoPanel.svelte
@@ -1,45 +1,53 @@
 <script lang="ts">
 	import Tabs from './Tabs.svelte';
-	import { selectedNode } from '$lib/stores/selectedNode';
+	import { selectedNodesStore, activeNode } from '$lib/stores/selectedNodes';
 
 	export let graphTitle: string;
-	export let tabs: { id: number; label: string }[] = [];
-	export let activeTabId: number;
-	export let setActiveTab: (id: number) => void;
-	export let showTabs: boolean = true;
 	export let buttons: { label: string; onClick: () => void; class?: string }[] = [];
 	export let worldContent: string | undefined = undefined;
+
+	$: tabs = $selectedNodesStore.nodes.map((n) => ({
+		id: n.data.id,
+		label: n.data.label
+	}));
 
 	$: useDropdown = tabs.length > 10;
 
 	function handleSelect(event: Event) {
 		const selectedId = (event.target as HTMLSelectElement).value;
-		setActiveTab(Number(selectedId));
+		selectedNodesStore.setActiveNode(selectedId);
 	}
 </script>
 
 <div class="rounded-4xl border-3 border-bg-base-300 text-base p-4 h-full w-full flex flex-col">
-	{#if showTabs}
+	{#if tabs.length > 0}
 		{#if useDropdown}
 			<div class="flex items-center">
 				<span class="font-bold">Tab:</span>
 				<select class="select select-bordered w-full max-w-xs" on:change={handleSelect}>
 					{#each tabs as tab (tab.id)}
-						<option value={tab.id} selected={tab.id === activeTabId}>{tab.label}</option>
+						<option value={tab.id} selected={tab.id === $selectedNodesStore.activeNodeId}
+							>{tab.label}</option
+						>
 					{/each}
 				</select>
 			</div>
 		{:else}
-			<Tabs {tabs} {activeTabId} {setActiveTab} />
+			<Tabs
+				{tabs}
+				activeTabId={$selectedNodesStore.activeNodeId}
+				setActiveTab={selectedNodesStore.setActiveNode}
+				closeTab={selectedNodesStore.removeNode}
+			/>
 		{/if}
 	{/if}
 
 	<div class="flex-1 rounded-xl overflow-hidden p-2 flex gap-4 min-h-0">
 		<!-- Left content area -->
 		<div class="flex-1 overflow-auto">
-			{#if $selectedNode}
+			{#if $activeNode}
 				<div class="flex flex-wrap items-center gap-4 mb-2">
-					<h2 class="text-xl font-semibold">{$selectedNode.data.label}</h2>
+					<h2 class="text-xl font-semibold">{$activeNode.data.label}</h2>
 					{#if buttons.length}
 						<div class="flex gap-2 flex-wrap">
 							{#each buttons as button (button.label)}
@@ -53,7 +61,7 @@
 						</div>
 					{/if}
 				</div>
-				<p>{$selectedNode.data.content}</p>
+				<p>{$activeNode.data.content}</p>
 			{:else if graphTitle}
 				<h2 class="text-xl font-semibold">{graphTitle}</h2>
 				{#if worldContent}

--- a/src/lib/components/QueryPanel.svelte
+++ b/src/lib/components/QueryPanel.svelte
@@ -8,7 +8,7 @@
 	<div class="p-1 rounded-xl h-full w-full relative">
 		<textarea class="textarea resize-none w-full h-full" placeholder="Ask me something"></textarea>
 		<div class="absolute bottom-4 right-6">
-			<button class="btn btn-ghost btn-lg" on:click={handleClick}> sumbit </button>
+			<button class="btn btn-ghost btn-lg" on:click={handleClick}> Submit</button>
 		</div>
 	</div>
 </div>

--- a/src/lib/components/QueryPanel.svelte
+++ b/src/lib/components/QueryPanel.svelte
@@ -4,9 +4,10 @@
 	}
 </script>
 
-<div class="rounded-l text-base h-full flex flex-col">
+<div class="rounded-4xl border-3 border-bg-base-300 text-base p-4 h-full flex flex-col">
 	<div class="p-1 rounded-xl h-full w-full relative">
-		<textarea class="textarea resize-none w-full h-full" placeholder="Ask me something"></textarea>
+		<textarea class="textarea border-none resize-none w-full h-full" placeholder="Ask me something"
+		></textarea>
 		<div class="absolute bottom-4 right-6">
 			<button class="btn btn-ghost btn-lg" on:click={handleClick}> Submit</button>
 		</div>

--- a/src/lib/components/Tabs.svelte
+++ b/src/lib/components/Tabs.svelte
@@ -1,17 +1,29 @@
 <script lang="ts">
-	export let tabs: { id: number; label: string }[] = [];
-	export let activeTabId: number;
-	export let setActiveTab: (id: number) => void;
+	export let tabs: { id: string; label: string }[] = [];
+	export let activeTabId: string | null;
+	export let setActiveTab: (id: string) => void;
+	export let closeTab: (id: string) => void;
 </script>
 
 <div role="tablist" class="tabs tabs-lift">
 	{#each tabs as tab (tab.id)}
-		<button
-			role="tab"
-			class="tab {tab.id === activeTabId ? 'tab-active' : ''}"
-			on:click={() => setActiveTab(tab.id)}
-		>
-			{tab.label}
-		</button>
+		<div class="relative flex items-center">
+			<button
+				role="tab"
+				class="tab pr-6 {tab.id === activeTabId ? 'tab-active' : ''}"
+				on:click={() => setActiveTab(tab.id)}
+				id={`tab-${tab.id}`}
+			>
+				{tab.label}
+			</button>
+			<button
+				type="button"
+				class="absolute right-1 text-sm w-4 h-4 flex items-center justify-center hover:text-red-700"
+				on:click|stopPropagation={() => closeTab(tab.id)}
+				aria-label="Close tab"
+			>
+				×
+			</button>
+		</div>
 	{/each}
 </div>

--- a/src/lib/stores/selectedNode.ts
+++ b/src/lib/stores/selectedNode.ts
@@ -1,4 +1,0 @@
-import type { GraphNode } from '$lib/types/graph';
-import { writable } from 'svelte/store';
-
-export const selectedNode = writable<GraphNode | null>(null);

--- a/src/lib/stores/selectedNodes.ts
+++ b/src/lib/stores/selectedNodes.ts
@@ -1,0 +1,75 @@
+import type { GraphNode } from '$lib/types/graph';
+import { writable, derived } from 'svelte/store';
+
+interface SelectedNodesStore {
+	nodes: GraphNode[];
+	activeNodeId: string | null;
+}
+
+const createSelectedNodesStore = () => {
+	const { subscribe, update } = writable<SelectedNodesStore>({
+		nodes: [],
+		activeNodeId: null
+	});
+
+	const addNode = (node: GraphNode) => {
+		update((store) => {
+			if (!store.nodes.find((n) => n.data.id === node.data.id)) {
+				return {
+					nodes: [...store.nodes, node],
+					activeNodeId: node.data.id
+				};
+			}
+			// If node is already in the list, just make it active
+			return {
+				...store,
+				activeNodeId: node.data.id
+			};
+		});
+	};
+
+	const removeNode = (nodeId: string) => {
+		update((store) => {
+			const newNodes = store.nodes.filter((n) => n.data.id !== nodeId);
+			let newActiveNodeId = store.activeNodeId;
+
+			// If the closed tab was the active one, select another tab
+			if (store.activeNodeId === nodeId) {
+				if (newNodes.length > 0) {
+					const closedIndex = store.nodes.findIndex((n) => n.data.id === nodeId);
+					const newActiveIndex = Math.max(0, closedIndex - 1);
+					newActiveNodeId = newNodes[newActiveIndex]?.data.id || null;
+				} else {
+					newActiveNodeId = null;
+				}
+			}
+
+			return {
+				nodes: newNodes,
+				activeNodeId: newActiveNodeId
+			};
+		});
+	};
+
+	const setActiveNode = (nodeId: string) => {
+		update((store) => ({
+			...store,
+			activeNodeId: nodeId
+		}));
+	};
+
+	return {
+		subscribe,
+		addNode,
+		removeNode,
+		setActiveNode
+	};
+};
+
+export const selectedNodesStore = createSelectedNodesStore();
+
+export const activeNode = derived(
+	selectedNodesStore,
+	($selectedNodesStore) =>
+		$selectedNodesStore.nodes.find((n) => n.data.id === $selectedNodesStore.activeNodeId) || null
+);

--- a/src/routes/worlds/+page.svelte
+++ b/src/routes/worlds/+page.svelte
@@ -3,12 +3,12 @@
 	import type { GraphData } from '$lib/types/graph';
 	import { goto } from '$app/navigation';
 	import { get } from 'svelte/store';
-	import { selectedNode } from '$lib/stores/selectedNode';
+	import { activeNode } from '$lib/stores/selectedNodes';
 
 	export let data: { graphData: GraphData };
 
 	const enterWorld = () => {
-		const node = get(selectedNode);
+		const node = get(activeNode);
 		if (node) {
 			const worldId = node.data.id;
 			goto(`/worlds/${worldId}`);


### PR DESCRIPTION
## Issue Closed

#40

## Summary

Tab logic set up previously as placeholder adjusted. Tabs for opening, switching, and closing nodes added to info panel

Write an overview and note any changes  

Opening a Tab: Clicking a graph node adds it to the selected nodes list or activates its existing tab.
Displaying Tabs: The Info Panel shows a tab for each selected node and displays the active node's content.
Switching Tabs: Clicking a tab sets it as active and updates the displayed node information.
Closing a Tab: Clicking the 'x' removes the node from the list and activates another tab if needed.
Dropdown Mode: When more than 10 tabs are open, they collapse into a dropdown with the same functionality.

## Packages Installed

None

## Tests

None as clicking node is canvas - trying to figure out how to do this.

## Accessibility

Adjustments to floating button added. 
